### PR TITLE
fix: normalize leading blank lines

### DIFF
--- a/Scripts/fix_md_spacing.py
+++ b/Scripts/fix_md_spacing.py
@@ -71,10 +71,10 @@ def normalize_spacing(lines):
         out.append(line)
         i += 1
 
-    # Collapse >2 consecutive blank lines to a single blank line
+    # Collapse consecutive blank lines to a single blank line
     compact = []
     for l in out:
-        if not (len(compact) >= 2 and compact[-1] == "\n" and l == "\n"):
+        if not (compact and compact[-1] == "\n" and l == "\n"):
             compact.append(l)
     return compact
 

--- a/tests/test_fix_md_spacing.py
+++ b/tests/test_fix_md_spacing.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+# Add Scripts directory to path for import
+sys.path.append(str(Path(__file__).resolve().parents[1] / "Scripts"))
+
+from fix_md_spacing import normalize_spacing
+
+
+def test_collapse_leading_blank_lines():
+    lines = ["\n", "\n", "# Heading\n"]
+    assert normalize_spacing(lines) == ["\n", "# Heading\n"]


### PR DESCRIPTION
## Summary
- ensure markdown spacing script collapses any run of blank lines
- add regression test for leading blank lines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae49c635cc8322821e20d63f03aaf7