### PR TITLE
Fix changelog header to reference GCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# GRCP Changelog
+# GCP Changelog
 
 ### Bug Fixes
 - fix: normalize leading blank lines (#125)
@@ -147,6 +147,7 @@
 - Refactor OpenSSF Scorecard workflow configuration
 
 ### Miscellaneous Tasks
+- chore(changelog): update and normalize spacing (#124)
 - chore(changelog): update and normalize spacing (#123)
 - chore(changelog): update and normalize spacing (#122)
 - chore(changelog): update and normalize spacing (#121)

--- a/Scripts/generate_changelog.py
+++ b/Scripts/generate_changelog.py
@@ -72,7 +72,7 @@ def main() -> None:
         if not assigned:
             GROUPS["Miscellaneous Tasks"].append(msg)
 
-    lines = ["# GRCP Changelog", ""]
+    lines = ["# GCP Changelog", ""]
     for group, commits in GROUPS.items():
         if commits:
             lines.append(f"### {group}")


### PR DESCRIPTION
## Summary
- rename changelog header to GCP in script and generated file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4b08f5288322a9bb7910383b93d2