### PR TITLE
feat(cli): pass version to audit command

### DIFF
--- a/CLI Bundle/Readme.md
+++ b/CLI Bundle/Readme.md
@@ -60,12 +60,17 @@ Options:
 - `--prompt PROMPT`: Invention prompt (required for runs).
 - `--phase PHASE`: Run a specific phase (e.g., -1 for worth-it sprint).
 - `--full-run`: Execute a complete cycle (uses full_run.py).
-- `--audit`: Perform audit checks (uses audit_utils.py).
+- `--audit`: Perform audit checks (uses audit_utils.py). Requires `--prompt` and `--version`.
 - `--help`: Show help.
 
 Example:
 ```bash
 python gcp_cli.py --version 47 --risk-tier R2 --prompt "Invent an EV charging optimizer" --full-run
+```
+
+Audit example:
+```bash
+python gcp_cli.py audit --prompt "Invent an EV charging optimizer" --version 47
 ```
 
 ### Utilities

--- a/CLI Bundle/gcp_cli.py
+++ b/CLI Bundle/gcp_cli.py
@@ -6,7 +6,7 @@ def main():
     parser = argparse.ArgumentParser(description="Genesis Recursive Code Protocol CLI")
     parser.add_argument("command", help="Command to run", choices=["init", "run", "full-run", "prompt", "audit", "export", "help"])
     parser.add_argument("--phase", type=int, help="Specify phase to run")
-    parser.add_argument("--file", type=str, help="File to audit")
+    parser.add_argument("--version", type=str, help="Protocol version")
     parser.add_argument("--prompt", type=str, help="Your invention idea")
     
     args = parser.parse_args()
@@ -25,8 +25,8 @@ def main():
         full_run.run_all()
     elif args.command == "prompt" and args.prompt:
         prompt_utils.run_prompt(args.prompt)
-    elif args.command == "audit" and args.file:
-        audit_utils.run_audit(args.file)
+    elif args.command == "audit" and args.prompt and args.version:
+        audit_utils.run_audit(args.prompt, args.version)
     elif args.command == "export":
         print("📄 Exporting session...")
     elif args.command == "help":


### PR DESCRIPTION
## Summary
- ensure `audit` subcommand supplies prompt and protocol version to `run_audit`
- document audit usage and version requirement in CLI Bundle README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae4b0bcb00832280c40ad395b0645a