### PR TITLE
Refine workflow audit to search for tag refs

### DIFF
--- a/tools/audit-workflows.sh
+++ b/tools/audit-workflows.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Quick audit to find likely unpinned actions inside .github/workflows
+# Quick audit to find likely unpinned actions inside .github/workflows.
+# SHA-pinned actions are ignored by this audit.
 set -euo pipefail
-echo "Scanning .github/workflows for 'uses:' lines that look unpinned..."
-grep -R --line-number "^\\s*uses: .*@" .github/workflows || true
+echo "Scanning .github/workflows for actions using loose refs (tags like 'v*', 'main', or 'master')..."
+grep -R --line-number -E "^\\s*uses: .+@(v[0-9]+|main|master)$" .github/workflows || true
 echo
-echo "Any 'uses: owner/repo@v1' or 'uses: owner/repo@main' should be reviewed and replaced with a pinned commit SHA for stronger supply-chain integrity."
+echo "Any 'uses: owner/repo@v1', 'uses: owner/repo@main', or 'uses: owner/repo@master' should be reviewed and replaced with a pinned commit SHA for stronger supply-chain integrity."


### PR DESCRIPTION
## Summary
- limit workflow audit to unpinned action refs like `@v*`, `@main`, or `@master`
- note that SHA-pinned actions are ignored

## Testing
- `bash tools/audit-workflows.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae4b0e1afc8322a7c898624262a2ad