### PR TITLE
ci: add pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,29 @@
+name: pre-commit
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.ipynb'
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install pip==23.3.1
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.8
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--profile", "black"]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy

--- a/Contributing.md
+++ b/Contributing.md
@@ -4,32 +4,32 @@ Thanks for your interest in GCP! We welcome improvements to code, docs, and prot
 
 ## Quick Start
 
-1. **Fork** the repo and create a branch: `git checkout -b feat/<topic>`  
-2. **Set up**: Python 3.10+, `pip install -r requirements.txt`  
-3. **Run checks**: lint/format/tests as provided (see CI config)  
+1. **Fork** the repo and create a branch: `git checkout -b feat/<topic>`
+2. **Set up**: Python 3.10+, `pip install -r requirements.txt` then `pre-commit install`
+3. **Run checks**: `pre-commit run --all-files` and `pytest -v`
 4. **Open a PR** with a clear description and checklist (see template)
 
 ## Development Guidelines
 
-- Follow Python best practices (typing, docstrings, tests).  
-- Keep PRs focused and small; link related issues.  
-- Explain **protocol impacts**: gates affected, artifacts updated, risk tier if applicable.  
+- Follow Python best practices (typing, docstrings, tests).
+- Keep PRs focused and small; link related issues.
+- Explain **protocol impacts**: gates affected, artifacts updated, risk tier if applicable.
 - Update docs/notebooks when behavior or public surfaces change.
 
 ## Commit & PR Style
 
-- Conventional commits recommended: `docs: …`, `feat: …`, `fix: …`, `refactor: …`.  
+- Conventional commits recommended: `docs: …`, `feat: …`, `fix: …`, `refactor: …`.
 - PRs must pass CI (build/tests/linters/security scans) and include relevant docs/CHANGELOG updates.
 
 ## Versioning & Compatibility
 
-- Use SemVer for public surfaces; run **compatibility tests** before merging.  
+- Use SemVer for public surfaces; run **compatibility tests** before merging.
 - Breaking changes require a major bump and deprecation guidance.
 
 ## Code of Conduct
 
-By participating, you agree to our [Code of Conduct](../CODE_OF_CONDUCT.md).
+By participating, you agree to our [Code of Conduct](./Code%20of%20Conduct.md).
 
 ## Security
 
-Please **do not** file public issues for vulnerabilities. Follow our [Security Policy](../SECURITY.md).
+Please **do not** file public issues for vulnerabilities. Follow our [Security Policy](./SECURITY.md).


### PR DESCRIPTION
## Summary
- add pre-commit configuration with hooks for formatting, linting, import sorting, and type checking
- run pre-commit in a dedicated GitHub Actions workflow
- document pre-commit usage in contributing guide and fix broken links

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/pre-commit.yml Contributing.md`
- `pytest -q`
- `pre-commit run --files tmp_bad.py` *(expected failure to validate hook)*

------
https://chatgpt.com/codex/tasks/task_e_68ae502eef288322b919ac69e48a2155