### PR TITLE
fix: update workflows to run repository scripts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
           python - <<'PY'
           import pathlib, tokenize, sys
           bad=[]
-          for p in map(pathlib.Path, ["setup.py","Scripts/generate_repo_toc.py"]):
+          for p in map(pathlib.Path, ["setup.py","scripts/generate_repo_toc.py"]):
               try:
                   with open(p, "rb") as f:
                       for _ in tokenize.tokenize(f.readline): pass

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -28,7 +28,9 @@ jobs:
 
       # Generate CHANGELOG.md using your script
       - name: Generate CHANGELOG.md
-        run: python Scripts/generate_changelog.py
+        run: |
+          python scripts/generate_changelog.py
+          python scripts/fix_md_spacing.py CHANGELOG.md
 
       # Create a pull request for the changelog update, sign commits with the GitHub Actions bot
       - name: Create Pull Request

--- a/.github/workflows/update-repo-structure.yml
+++ b/.github/workflows/update-repo-structure.yml
@@ -33,9 +33,8 @@ jobs:
 
       - name: Build repo tree and patch README
         run: |
-          python - <<'PY'
-          # ... your existing Python script that updates README.md ...
-          PY
+          python scripts/update_repo_structure.py
+          python scripts/fix_md_spacing.py README.md
 
       # Create a PR for the README update
       - name: Create Pull Request

--- a/.github/workflows/update-toc-file.yml
+++ b/.github/workflows/update-toc-file.yml
@@ -33,9 +33,8 @@ jobs:
 
       - name: Generate "Table Of Contents.md"
         run: |
-          python - <<'PY'
-          # ... your existing Python script that generates Table Of Contents.md ...
-          PY
+          python scripts/generate_repo_toc.py
+          python scripts/fix_md_spacing.py "Table Of Contents.md"
 
       # Show the diff (optional for debugging)
       - name: Show diff


### PR DESCRIPTION
## Summary
- run repository utilities in update-repo-structure and update-toc workflows
- invoke changelog generator with correct path and normalize spacing
- fix CodeQL workflow path to TOC generator script

## Testing
- `pre-commit run --files .github/workflows/update-repo-structure.yml .github/workflows/update-toc-file.yml .github/workflows/generate-changelog.yml .github/workflows/codeql.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae51f842188322b40206545dcc736d