### PR TITLE
chore: clarify security policy and restrict workflow tokens

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -14,6 +14,9 @@ on:
       - '.markdownlintignore'
       - '.github/workflows/markdownlint.yml'
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,7 @@ We are particularly interested in reports of vulnerabilities that could lead to:
 Vulnerabilities solely affecting older, unsupported versions (v48 or earlier) are not prioritized but may still be acknowledged.
 
 ## Reporting a Vulnerability
+Please report suspected vulnerabilities privately to **security@lazyxeon.com** or via the GitHub Security Advisories form at <https://github.com/lazyxeon/Genesis-Code-Protocol/security/advisories/new>. We will acknowledge reports within **3 business days** and aim to resolve confirmed issues within **60 days**.
 
 To report a vulnerability, **please use the private reporting channel** so we can assess and address the issue before public disclosure:
 


### PR DESCRIPTION
## Summary
- make security contact and disclosure timeline explicit
- restrict markdownlint workflow token to read-only

## Testing
- `scorecard --local . --checks Security-Policy --format json`
- `scorecard --local . --checks Token-Permissions --format json`
- `pre-commit run --files SECURITY.md .github/workflows/markdownlint.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ae5b1e07508322a59a3f667a9cd4bc