### PR TITLE
Ensure pytest available in Python CI

### DIFF
--- a/.github/workflows/Python-CI.yml
+++ b/.github/workflows/Python-CI.yml
@@ -25,11 +25,11 @@ jobs:
         run: |
           python -m pip install pip==23.3.1
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install flake8==7.0.0
+          pip install flake8==7.0.0 pytest==8.4.1
       - name: Lint with Flake8
         run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics || true
-          flake8 . --count --max-complexity=10 --max-line-length=127 --statistics || true
+          python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics || true
+          python -m flake8 . --count --max-complexity=10 --max-line-length=127 --statistics || true
       - name: Run tests
         run: |
           if [ -d "tests" ] && [ "$(ls -A tests)" ]; then python -m pytest -v; else echo 'No tests found.'; fi


### PR DESCRIPTION
## Summary
- install pytest alongside flake8 in Python CI workflow
- invoke flake8 via `python -m` for consistent environment handling

## Testing
- `python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `python -m flake8 . --count --max-complexity=10 --max-line-length=127 --statistics`
- `python -m pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_68ae5bfc2188832280550e6c1e3bbe2d