### PR TITLE
fix: repair Dockerfile and workflow dependencies

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Install dependencies required by the changelog script
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install gitpython
+
       # Generate CHANGELOG.md using your script
       - name: Generate CHANGELOG.md
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # syntax=docker/dockerfile:1.7
-<<<<<< dependabot/docker/python-3.13-slim
-FROM python:3.13-slim AS runner
-=======
 # Pin to a specific digest of python:3.11-slim
 FROM python:3.11-slim@sha256:4c904a8c1ece1177ddba2e4ecc6f241577637aa1d4db448e2393ae25d800cc85 AS runner
->>>>>> main
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Summary
- resolve merge conflict in Dockerfile by pinning to python:3.11-slim digest
- install GitPython in changelog workflow before generating the log

## Testing
- `pre-commit run --files Dockerfile .github/workflows/generate-changelog.yml`
- `pytest tests/test_fix_md_spacing.py -q`
- `actionlint .github/workflows/generate-changelog.yml .github/workflows/build-and-push-ghcr.yml`
- `docker run --rm -i hadolint/hadolint < Dockerfile` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68af061b8e948322b1c6a2d11e638b29