### PR TITLE
chore: enable manual workflow dispatch for all workflows

### DIFF
--- a/.github/workflows/Python-CI.yml
+++ b/.github/workflows/Python-CI.yml
@@ -8,6 +8,7 @@ on:
       - '**/*.ipynb'
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,12 +4,14 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   release:
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     branches: ["main"]
   schedule:
     - cron: '0 4 * * 0'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,7 @@ name: Dependency Review on PR
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,6 +12,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -13,6 +13,7 @@ on:
       - '.markdownlint.yml'
       - '.markdownlintignore'
       - '.github/workflows/markdownlint.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
       - '**/*.ipynb'
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -4,6 +4,7 @@ name: Release Bundle
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 # Default permissions for all jobs
 permissions:
@@ -11,6 +12,7 @@ permissions:
 
 jobs:
   bundle:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     # This job needs write access to upload the bundle and SBOMs
     permissions:

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -4,6 +4,7 @@ name: Sign Release Artifacts
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 # Default permissions are read-only
 permissions:
@@ -11,6 +12,7 @@ permissions:
 
 jobs:
   sign-release:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     # The job needs write access to upload the signed artifacts, and
     # id-token to authenticate with Sigstore for keyless signing

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/validate-notebooks.yml
+++ b/.github/workflows/validate-notebooks.yml
@@ -6,6 +6,7 @@ on:
     paths: [ "**/*.ipynb" ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` manual run trigger to all workflows
- guard release and PR-specific workflows to avoid unintended runs when mass triggered

## Testing
- `pre-commit run --files .github/workflows/Python-CI.yml .github/workflows/auto-merge-dependabot.yml .github/workflows/auto-release.yml .github/workflows/codeql.yml .github/workflows/dependency-review.yml .github/workflows/markdownlint.yml .github/workflows/pre-commit.yml .github/workflows/release-bundle.yml .github/workflows/release-sign.yml .github/workflows/security-scan.yml .github/workflows/validate-notebooks.yml`
- `python - <<'PY'\nimport yaml, glob, sys\nmissing = []\nfor path in glob.glob('.github/workflows/*.yml'):\n    with open(path) as f:\n        data = yaml.safe_load(f)\n    on = data.get('on') or data.get(True)\n    if isinstance(on, dict) and 'workflow_dispatch' in on:\n        continue\n    else:\n        missing.append(path)\nif missing:\n    print('Missing:', missing)\n    sys.exit(1)\nelse:\n    print('All workflows have workflow_dispatch')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68af0f378f108322a5d3c74d4c7bdb5d