### PR TITLE
Fix Docker build by unpinning Debian packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates=20240203 curl=7.88.1-10 && \
+    ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Install only dependencies first to leverage layer caching

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,10 @@
-<<<<<< codex/develop-and-implement-matrix-ci
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-=======
-<<<<<< codex/analyze-failing-github-workflows
 """Test configuration."""
-=======
->>>>>> main
+
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
->>>>>> main
+# Ensure the project's ``src`` directory is on ``sys.path`` so that test modules
+# can import the package without installing it. This mirrors the layout used in
+# development and keeps tests lightweight.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+


### PR DESCRIPTION
## Summary
- remove pinned ca-certificates and curl versions so the Docker image can be built against the latest Debian packages
- clean up test configuration to resolve merge artifacts

## Testing
- `pytest` *(fails: SyntaxError from merge conflicts in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68af1dfb3b788322bb58f5ebf2f64bde