### PR TITLE
fix trigger-all-workflows permissions

### DIFF
--- a/.github/workflows/trigger-all-workflows.yml
+++ b/.github/workflows/trigger-all-workflows.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  workflow: write
+  actions: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary
- fix invalid workflow permission key to allow triggering all workflows

## Testing
- `pre-commit run --files .github/workflows/trigger-all-workflows.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af2445706c83229063ca2b5fb48b15