### PR TITLE
fix: adjust curl installation for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates=20240203 curl=7.88.1-10 && \
+    ca-certificates=20240203 curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Install only dependencies first to leverage layer caching


### PR DESCRIPTION
## Summary
- unpin curl package in Dockerfile to prevent apt failures during container build

## Testing
- `pytest -q`
- ⚠️ `docker build -t gcp-test .` *(command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68af247b315483228b6563e8cc34cc49