### PR TITLE
Add pluggy and pytest dependencies for CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 # Keep this file even if empty; Dockerfile COPY expects it to exist.
 # Add your real dependencies here as you evolve the CLI.
+pluggy>=1.5
+pytest>=8


### PR DESCRIPTION
## Summary
- ensure pytest and its pluggy plugin are installed via requirements.txt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af24b675b483228b0003307f328f09