### PR TITLE
Fix pre-commit workflow dependency installation

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install pip==23.3.1
-          pip install --no-deps pre-commit==4.3.0
+          pip install pre-commit==4.3.0
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
## Summary
- ensure pre-commit's GitHub workflow installs dependencies so cfgv is available

## Testing
- `pre-commit run --files .github/workflows/pre-commit.yml --show-diff-on-failure`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af24ec191c8322b96f6a01ecc7c10f