### PR TITLE
Fix Dockerfile apt packages to avoid build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates=20240203 curl=7.88.1-10 && \
+    ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Install only dependencies first to leverage layer caching

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates=20240203 curl=7.88.1-10 && \
+    ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Install only dependencies first to leverage layer caching


### PR DESCRIPTION
## Summary
- avoid pinning ca-certificates and curl versions in Dockerfiles to prevent missing package errors during `apt-get install`

## Testing
- `pytest`
- `docker build -t gcp_test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2566b60483229742c4283515e0f0