### PR TITLE
Fix lint error and unpin Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates=20240203 curl \
+    ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install only dependencies first to leverage layer caching

--- a/src/config.py
+++ b/src/config.py
@@ -11,7 +11,9 @@ class Config:
         default_factory=lambda: os.getenv("WF_REPORT_PATH", "report.json")
     )
     fail_step: bool = field(
-        default_factory=lambda: os.getenv("WF_FAIL_STEP", "false").lower() == "true",
+        default_factory=lambda: (
+            os.getenv("WF_FAIL_STEP", "false").lower() == "true"
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- Fix flake8 E501 in Config by wrapping WF_FAIL_STEP lookup
- Unpin ca-certificates in Dockerfile to avoid outdated package failures

## Testing
- `flake8 src tests`
- `pytest -q`
- `docker build -t test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68af3f49e7dc8322922bc4cf3b216d3a