### PR TITLE
Use ruff for linting in matrix CI

### DIFF
--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt ruff
       - name: Lint
-        run: flake8 src tests
+        run: ruff check src tests
       - name: Test
         run: pytest -q


### PR DESCRIPTION
## Summary
- fix Matrix CI lint step by installing ruff and running `ruff check`

## Testing
- `pre-commit run --files .github/workflows/matrix-ci.yml`
- `ruff check src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4892a400832281d8e3f9853f631b