### PR TITLE
Fix pre-commit formatting issue in config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -11,9 +11,7 @@ class Config:
         default_factory=lambda: os.getenv("WF_REPORT_PATH", "report.json")
     )
     fail_step: bool = field(
-        default_factory=lambda: (
-            os.getenv("WF_FAIL_STEP", "false").lower() == "true"
-        ),
+        default_factory=lambda: (os.getenv("WF_FAIL_STEP", "false").lower() == "true"),
     )
 
 


### PR DESCRIPTION
## Summary
- format Config.fail_step default_factory with Black to satisfy formatting checks

## Testing
- `pre-commit run --all-files --show-diff-on-failure`
- `ruff check src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af562262f48322a16a6e7061fd6560