### PR TITLE
Fix Python type annotations for broader compatibility

### DIFF
--- a/Notebooks/Duality Unzipped Ouput/api_server.py
+++ b/Notebooks/Duality Unzipped Ouput/api_server.py
@@ -1,10 +1,12 @@
+from typing import Optional
+
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 class PolicyUpdate(BaseModel):
-    lte_budget_mb: int | None = None
-    parity_max_pct: float | None = None
-    jitter_hold_ms: int | None = None
+    lte_budget_mb: Optional[int] = None
+    parity_max_pct: Optional[float] = None
+    jitter_hold_ms: Optional[int] = None
 
 def build_app(state):
     app = FastAPI(title="DUALITY Agent API", version="0.1.0")

--- a/src/fuzz.py
+++ b/src/fuzz.py
@@ -1,9 +1,11 @@
+from typing import Optional
+
 from .config import Config
 from .errors import RetryableError
 from .logging_utils import log
 
 
-def main(data: bytes, cfg: Config | None = None) -> bytes:
+def main(data: bytes, cfg: Optional[Config] = None) -> bytes:
     cfg = cfg or Config()
     log("fuzz.start")
     if cfg.fail_step:

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
+from typing import Optional
 
 from .config import Config
 from .logging_utils import log
 
 
-def main(cfg: Config | None = None) -> bytes:
+def main(cfg: Optional[Config] = None) -> bytes:
     cfg = cfg or Config()
     log("ingest.start", source=cfg.source_archive)
     data = b"dummy"

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from . import errors, fuzz, ingest, report, rollback, scan
 from .config import Config
 
 
-def run(cfg: Config | None = None) -> str:
+def run(cfg: Optional[Config] = None) -> str:
     """Execute the workflow and return path to the report."""
     cfg = cfg or Config()
     try:

--- a/src/report.py
+++ b/src/report.py
@@ -1,11 +1,12 @@
 import json
 from pathlib import Path
+from typing import Optional
 
 from .config import Config
 from .logging_utils import log
 
 
-def main(findings: dict, cfg: Config | None = None) -> str:
+def main(findings: dict, cfg: Optional[Config] = None) -> str:
     cfg = cfg or Config()
     log("report.start")
     path = Path(cfg.report_path)

--- a/src/scan.py
+++ b/src/scan.py
@@ -1,15 +1,13 @@
-from __future__ import annotations
-
-from typing import Dict
+from typing import Dict, List, Optional
 
 from .config import Config
 from .logging_utils import log
 
 
-def main(data: bytes, cfg: Config | None = None) -> dict[str, list[str]]:
+def main(data: bytes, cfg: Optional[Config] = None) -> Dict[str, List[str]]:
     cfg = cfg or Config()
     log("scan.start")
-    findings: dict[str, list[str]] = {"vulnerabilities": []}
+    findings: Dict[str, List[str]] = {"vulnerabilities": []}
     log("scan.complete", vulnerabilities=len(findings["vulnerabilities"]))
     return findings
 


### PR DESCRIPTION
## Summary
- replace `| None` and built-in collection generics with typing aliases
- ensure modules run on Python 3.8+ without TypeErrors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5815c3c48322b7152c517f66e29f