### PR TITLE
Fix typing compatibility in fix_md_spacing utility

### DIFF
--- a/scripts/fix_md_spacing.py
+++ b/scripts/fix_md_spacing.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Utility to normalize spacing in Markdown files."""
 
+from __future__ import annotations
+
 import re
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
- ensure Markdown spacing normalizer works on older Python versions by postponing evaluation of type hints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af594549a48322819c12015fa8ed3b