### PR TITLE
feat: add github actions stability workflow

### DIFF
--- a/EXIT_WIZARD.txt
+++ b/EXIT_WIZARD.txt
@@ -19,5 +19,5 @@ Exit Wizard
 
 5. Emit release receipt
    commit=$(git rev-parse HEAD)
-   image=$(docker images -q gcp-protocol:latest)
+   image=$(docker images -q github-actions-stability:latest)
    printf '{"commit":"%s","image":"%s"}' "$commit" "$image" > release_receipt.json

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 >pytest -q
 
 build:
->docker build -t gcp-protocol .
+>docker build -t github-actions-stability .
 
 sbom:
 >syft . -o json > sbom.json
@@ -21,7 +21,7 @@ sign:
 
 package: build sbom
 >mkdir -p dist
->zip -r dist/gcp-protocol-bundle.zip workflow_manifest.json integration_contract.md observability.yaml governance.yaml cost_model.md security.md src tests Makefile
+>zip -r dist/github-actions-stability-bundle.zip workflow_manifest.json integration_contract.md observability.yaml governance.yaml cost_model.md security.md src tests Makefile
 
 canary:
 >echo "Launching canary deployment"

--- a/cost_model.md
+++ b/cost_model.md
@@ -2,16 +2,16 @@
 
 | Scenario | Runs/Month | Cost/Run (USD) | Monthly Cost (USD) |
 |---------|------------|----------------|--------------------|
-| Low     | 100        | 0.50           | 50                 |
-| Medium  | 1000       | 0.45           | 450                |
-| High    | 5000       | 0.40           | 2000               |
+| Low     | 300        | 0.01           | 3                  |
+| Medium  | 3_000      | 0.01           | 30                 |
+| High    | 30_000     | 0.009          | 270                |
 
 ## Optimization Plan
 
-- **Hot path**: cache scorecard results to reduce API calls (est. 20% cost drop).
-- **Cold path**: batch remediation PR creation (est. 10% cost drop).
+- **Hot path**: cache workflow run queries to cut API calls (≈15% cost drop).
+- **Cold path**: batch report uploads to object storage (≈10% cost drop).
 
 ## Tuning Levers
 
-- Adjust concurrency: ±15% cost impact.
-- Enable delta scanning: 25% runtime reduction with moderate risk.
+- Adjust parallelism: ±20% cost impact.
+- Enable incremental analysis: 25% runtime reduction with low risk.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,22 +1,22 @@
-# Secure Repo Scorecard Remediation Runbook
+# GitHub Actions Stability Runbook
 
 ## Overview
 
-This runbook guides operators through running and troubleshooting the automated remediation workflow that leverages StepSecurity's `secure-repo` to fix OpenSSF Scorecard vulnerabilities.
+This runbook guides operators through running and troubleshooting the workflow that analyzes GitHub Actions runs to detect failing workflows.
 
 ## Normal Operation
 
-1. Ensure `SECURE_REPO_TOKEN` is set in the environment.
+1. Ensure `GITHUB_TOKEN` is set in the environment.
 2. Execute `make install` to install dependencies.
 3. Run `make test` to verify the workflow passes all gates.
 4. Deploy using `make build` and run the workflow container.
 
 ## Troubleshooting
 
-- **Failure during scan**: Inspect logs for `scan_scorecard` step.
-- **Remediation issues**: Verify network access to StepSecurity and GitHub APIs.
-- **Rollback**: Execute `python -m src.rollback` to revert applied patches.
+- **Failure during ingest**: Inspect logs for network issues with the GitHub API.
+- **Analysis issues**: Verify repository name and token permissions.
+- **Rollback**: Execute `python -m src.rollback` to revert actions.
 
 ## Escalation
 
-Contact the DevSecOps team on call if remediation cannot be completed after one retry.
+Contact the DevOps team on call if stability cannot be confirmed after one retry.

--- a/governance.yaml
+++ b/governance.yaml
@@ -1,22 +1,23 @@
 risk_level: r2
 controls:
-  - code_review: required
-  - security_scan: required
+  code_review: required
+  security_scan: required
+  tests: required
 change_types:
   patch:
     reviewers: 1
     checks: [tests]
   minor:
     reviewers: 2
-    checks: [tests, sbom]
+    checks: [tests, security]
   major:
     reviewers: 3
-    checks: [tests, sbom, perf]
+    checks: [tests, security, perf]
 release_policy:
   canary_percent: 10
   error_budget_guard: 0.01
   auto_rollback: true
 provenance:
-  attestation: cosign attest
-  signing: cosign sign
+  build_attestation: cosign attest
+  artifact_signing: cosign sign
   sbom_policy: fail_on_critical

--- a/integration_contract.md
+++ b/integration_contract.md
@@ -1,42 +1,39 @@
-# Integration Contract: secure-repo-scorecard-remediation
+# Integration Contract: github-actions-stability
 
 ## Interfaces
 
 ### CLI
 
 ```bash
-python -m src.scan --repo <owner/repo>
-python -m src.remediate --report report.json
+python -m src.main --repo <owner/repo>
 ```
 
 ### HTTP
 
-`POST /remediate` with body `{ "repo": "owner/repo" }`
+`POST /stability` with body `{ "repo": "owner/repo" }`
 
 ### Webhook
 
-GitHub `pull_request` events trigger remediation.
+GitHub `workflow_run` events trigger analysis.
 
 ### Queue
 
-Messages on `secure-repo-remediation` queue follow schema:
+Messages on `gha-stability` queue follow schema:
 
 ```json
 {
   "repo": "owner/repo",
+  "branch": "main",
   "commit": "sha",
-  "action": "scan|remediate"
+  "action": "analyze"
 }
 ```
 
 ## Authentication
 
-- CLI: OIDC token via `SECURE_REPO_TOKEN`.
-- HTTP/Queue: Bearer token in `Authorization` header.
-
-Rate limit: 60 req/min per repo.
-
-All requests must include an `X-Request-ID` header for traceability.
+- CLI/HTTP/Queue: Bearer token via `GITHUB_TOKEN`.
+- All requests must include an `X-Request-ID` header.
+- Rate limit: 60 req/min per repo.
 
 Error shape:
 
@@ -50,4 +47,4 @@ Idempotency key = SHA256 of repo and commit. Duplicate keys are ignored.
 
 ## Versioning
 
-Semantic versioning with 6-month deprecation window. Backward compatibility tests run via `tests/contract.test.py`.
+Semantic versioning with 6-month deprecation window. Backward compatibility tests run via `tests/test_contract.py`.

--- a/observability.yaml
+++ b/observability.yaml
@@ -1,12 +1,20 @@
 traces:
+  service_name: github-actions-stability
   spans:
-    ingest: {parent: root}
-    scan: {parent: ingest}
-    remediate: {parent: scan}
+    bwb.ingest: {parent: root, children: [bwb.fuzz]}
+    bwb.fuzz: {parent: bwb.ingest, children: [bwb.scan]}
+    bwb.scan: {parent: bwb.fuzz, children: [bwb.report]}
+    bwb.report: {parent: bwb.scan}
 metrics:
   counters:
-    records_ingested:
-      unit: count
+    runs_fetched:
+      unit: runs
+      cardinality: low
+    workflows_scanned:
+      unit: workflows
+      cardinality: low
+    reports_generated:
+      unit: reports
       cardinality: low
   timers:
     duration_ms:
@@ -19,13 +27,13 @@ logs:
 code_snippets:
   python: |
     from opentelemetry import trace
-    tracer = trace.get_tracer("gcp-protocol")
-    with tracer.start_as_current_span("ingest"):
+    tracer = trace.get_tracer("github-actions-stability")
+    with tracer.start_as_current_span("bwb.ingest"):
         ...
   node: |
     const { trace } = require("@opentelemetry/api");
-    const tracer = trace.getTracer("gcp-protocol");
-    tracer.startActiveSpan("ingest", span => {
+    const tracer = trace.getTracer("github-actions-stability");
+    tracer.startActiveSpan("bwb.ingest", span => {
       // ...
       span.end();
     });

--- a/security.md
+++ b/security.md
@@ -2,16 +2,16 @@
 
 ## Threat Model (STRIDE)
 
-- **Spoofing**: Mitigated via OIDC authentication.
-- **Tampering**: Artifacts signed with Sigstore.
+- **Spoofing**: OIDC authentication enforced for API calls.
+- **Tampering**: Artifacts signed with Sigstore; SBOM verified.
 - **Repudiation**: Audit logs stored for 90 days.
-- **Information Disclosure**: Secrets stored in GitHub Actions secrets.
+- **Information Disclosure**: `GITHUB_TOKEN` kept in secret store.
 - **Denial of Service**: Rate limiting at 60 req/min.
-- **Elevation of Privilege**: Least-privilege GitHub token.
+- **Elevation of Privilege**: Token scoped read-only.
 
 ## Secret Management
 
-`SECURE_REPO_TOKEN` sourced from environment; rotated every 90 days.
+`GITHUB_TOKEN` sourced from environment; rotated every 90 days.
 
 ## SBOM
 
@@ -21,5 +21,5 @@ Generated via `syft . -o json > sbom.json`. Pipeline fails on critical vulnerabi
 
 | Data              | Retention | Notes                     |
 |-------------------|-----------|---------------------------|
-| Scorecard Reports | 30 days   | Stored in internal bucket |
-| Remediation PRs   | 90 days   | GitHub retains metadata   |
+| Stability Reports | 90 days   | Stored in internal bucket |
+| Workflow Logs     | 30 days   | Redacted for PII          |

--- a/src/config.py
+++ b/src/config.py
@@ -22,7 +22,7 @@ class Settings:
 
     @staticmethod
     def from_env(repo: str) -> "Settings":
-        token = os.environ.get("SECURE_REPO_TOKEN", "")
+        token = os.environ.get("GITHUB_TOKEN", "")
         if not token:
-            raise RuntimeError("SECURE_REPO_TOKEN not set")
+            raise RuntimeError("GITHUB_TOKEN not set")
         return Settings(repo=repo, token=token)

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -7,6 +7,6 @@ from .logging_utils import log
 def main(cfg: Optional[Config] = None) -> bytes:
     cfg = cfg or Config()
     log("ingest.start", source=cfg.source_archive)
-    data = b"dummy"
+    data = b"workflow_runs"
     log("ingest.complete", size=len(data))
     return data

--- a/src/scan.py
+++ b/src/scan.py
@@ -7,12 +7,12 @@ from .logging_utils import log
 def main(data: bytes, cfg: Optional[Config] = None) -> Dict[str, List[str]]:
     cfg = cfg or Config()
     log("scan.start")
-    findings: Dict[str, List[str]] = {"vulnerabilities": []}
-    log("scan.complete", vulnerabilities=len(findings["vulnerabilities"]))
+    findings: Dict[str, List[str]] = {"unstable_workflows": []}
+    log("scan.complete", unstable=len(findings["unstable_workflows"]))
     return findings
 
 
 def scan_repository(repo: str) -> Dict[str, int]:
-    """Simulate a scorecard scan returning counts of findings."""
+    """Simulate checking workflow runs and returning counts of failures."""
     log("scan.repo", repo=repo)
-    return {"critical": 0, "high": 1, "medium": 2, "low": 0}
+    return {"failures": 0, "success": 1}

--- a/tests/test_e2e_smoke.py
+++ b/tests/test_e2e_smoke.py
@@ -14,4 +14,4 @@ def test_e2e_smoke(tmp_path, monkeypatch) -> None:
     result = main.run()
     assert Path(result).exists()
     data = json.loads(Path(result).read_text())
-    assert "vulnerabilities" in data
+    assert "unstable_workflows" in data

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -15,7 +15,7 @@ def test_no_secret_in_logs() -> None:
     logger = get_logger("test")
     logger.handlers = [handler]
     logger.info("hello")
-    assert "SECURE_REPO_TOKEN" not in stream.getvalue()
+    assert "GITHUB_TOKEN" not in stream.getvalue()
 
 
 def test_policy_enforces_fail_on_critical() -> None:

--- a/workflow_manifest.json
+++ b/workflow_manifest.json
@@ -1,36 +1,85 @@
 {
   "$schema": "https://example.com/schemas/workflow_manifest_v1.json",
-  "id": "bwb::secure-repo-scorecard-remediation::v1",
+  "id": "bwb::github-actions-stability::v1",
   "version": "1.0.0",
-  "business_goal": "Automatically scan repositories and produce remediation reports",
-  "value_hypothesis": "Improved security posture through automated analysis",
-  "inputs": [],
-  "outputs": [],
+  "business_goal": "Detect and report failing GitHub Actions workflows across branches",
+  "value_hypothesis": "Reduced CI failures and faster merge cycles through early detection of unstable pipelines",
+  "inputs": [
+    {"name": "repository", "type": "text", "source": "api", "validation": "<owner>/<repo>"}
+  ],
+  "outputs": [
+    {"name": "stability_report", "type": "json", "retention_days": 90, "consumer": "devops"}
+  ],
   "SLOs": {"latency_ms_p95": 1200, "success_rate": 0.99, "error_budget_month": 0.01},
-  "constraints": [],
+  "constraints": ["must run on ubuntu-latest", "avoid secrets exposure"],
   "operational_env": "container",
   "security": {
     "data_classes": ["internal"],
-    "secrets": ["ENV:SECURE_REPO_TOKEN"],
-    "iam": [],
+    "secrets": ["ENV:GITHUB_TOKEN"],
+    "iam": [{"principal": "workflow-sa", "permissions": ["read:repo-status"]}],
     "supply_chain": {"sbom": true, "signing": "sigstore", "policy": "fail_on_critical"}
   },
-  "compliance": {},
+  "compliance": {"pii": false, "gdpr": "n/a", "sox": "n/a", "hipaa": false},
   "tooling": {
-    "images": [],
+    "images": ["ghcr.io/org/github-actions-stability:1.0.0"],
     "runtimes": ["python3.11"],
-    "libraries": []
+    "libraries": ["requests", "pytest", "opentelemetry-sdk"]
   },
   "steps": [
-    {"name": "ingest", "kind": "task", "entrypoint": "src/ingest.py:main"},
-    {"name": "scan", "kind": "task", "entrypoint": "src/scan.py:main"},
-    {"name": "report", "kind": "task", "entrypoint": "src/report.py:main"}
+    {
+      "name": "ingest",
+      "kind": "task",
+      "entrypoint": "src/ingest.py:main",
+      "contracts": {"in": ["inputs[*]"], "out": ["raw_runs"]},
+      "retries": {"max": 3, "backoff": "exponential", "jitter": true},
+      "timeout_s": 60,
+      "idempotency_key": "hash(input)",
+      "resources": {"cpu": "500m", "mem": "512Mi"},
+      "metrics": {"counters": ["runs_fetched"], "timers": ["duration_ms"]},
+      "otel_spans": ["bwb.ingest"]
+    },
+    {
+      "name": "fuzz",
+      "kind": "task",
+      "entrypoint": "src/fuzz.py:main",
+      "contracts": {"in": ["raw_runs"], "out": ["fuzzed_runs"]},
+      "retries": {"max": 3, "backoff": "exponential", "jitter": true},
+      "timeout_s": 30,
+      "idempotency_key": "hash(input)",
+      "resources": {"cpu": "200m", "mem": "256Mi"},
+      "metrics": {"counters": ["cases_processed"], "timers": ["duration_ms"]},
+      "otel_spans": ["bwb.fuzz"]
+    },
+    {
+      "name": "scan",
+      "kind": "task",
+      "entrypoint": "src/scan.py:main",
+      "contracts": {"in": ["fuzzed_runs"], "out": ["analysis"]},
+      "retries": {"max": 3, "backoff": "exponential", "jitter": true},
+      "timeout_s": 60,
+      "idempotency_key": "hash(input)",
+      "resources": {"cpu": "500m", "mem": "512Mi"},
+      "metrics": {"counters": ["workflows_scanned"], "timers": ["duration_ms"]},
+      "otel_spans": ["bwb.scan"]
+    },
+    {
+      "name": "report",
+      "kind": "task",
+      "entrypoint": "src/report.py:main",
+      "contracts": {"in": ["analysis"], "out": ["stability_report"]},
+      "retries": {"max": 3, "backoff": "exponential", "jitter": true},
+      "timeout_s": 30,
+      "idempotency_key": "hash(input)",
+      "resources": {"cpu": "200m", "mem": "256Mi"},
+      "metrics": {"counters": ["reports_generated"], "timers": ["duration_ms"]},
+      "otel_spans": ["bwb.report"]
+    }
   ],
-  "dependencies": [],
+  "dependencies": ["https://api.github.com"],
   "runbook": "docs/runbook.md",
   "failover": {"strategy": "brownout_then_rollback", "rpo_minutes": 5, "rto_minutes": 15},
   "rollback": {"guard": "Gate:RISK", "actions": ["revert:deployment", "restore:db_snapshot_t-1"]},
   "artifact_plan": [
-    {"path": "dist/secure-repo-scorecard-remediation-bundle.zip", "contains": ["manifest", "contracts", "tests", "sbom", "runbook"]}
+    {"path": "dist/github-actions-stability-bundle.zip", "contains": ["manifest", "contracts", "tests", "sbom", "runbook"]}
   ]
 }


### PR DESCRIPTION
## Summary
- define `github-actions-stability` workflow manifest, contract, and observability spec
- implement skeleton ingest/scan/report with tests
- document security, cost, and governance; update build scripts and runbook

## Testing
- `pre-commit run --files EXIT_WIZARD.txt Makefile cost_model.md docs/runbook.md governance.yaml integration_contract.md observability.yaml security.md src/config.py src/ingest.py src/scan.py tests/test_e2e_smoke.py tests/test_security.py workflow_manifest.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5c23d8388322a04abdb2e7867fbf