### PR TITLE
Fix automated release workflows

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -3,28 +3,21 @@ name: Auto-merge Dependabot PRs
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
-  merge:
+  enable-auto-merge:
     if: github.actor == 'dependabot[bot]'
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Merge dependabot PR
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@64e723d4b74a914792717a4a11d82cbeb9631d58
         with:
-          script: |
-            const pr = context.payload.pull_request;
-            await github.rest.pulls.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-              merge_method: 'squash'
-            });
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,12 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Create Release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: "Auto-generated release for ${{ github.ref }}"
-          draft: false
-          prerelease: false
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          body: Auto-generated release for ${{ github.ref_name }}

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -3,7 +3,7 @@ name: Release Bundle
 # Run this workflow when a new release is created
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 # Default permissions for all jobs
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   bundle:
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     # This job needs write access to upload the bundle and SBOMs
     permissions:


### PR DESCRIPTION
## Summary
- simplify auto-release workflow with softprops action
- trigger release bundle on published releases
- enable auto-merge for Dependabot PRs

## Testing
- `pre-commit run --files .github/workflows/auto-merge-dependabot.yml .github/workflows/auto-release.yml .github/workflows/release-bundle.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5f86dc4c83228900753ddb787a78