### PR TITLE
feat: enable manual mock security scans

### DIFF
--- a/.github/workflows/manual-mock-run.yml
+++ b/.github/workflows/manual-mock-run.yml
@@ -1,0 +1,26 @@
+name: Manual Mock Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  trigger-security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch security scan in mock mode
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'security-scan.yml',
+              ref: context.ref,
+              inputs: { mock: 'true' }
+            });
+            core.info('Security scan mock run dispatched');

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      mock:
+        description: "Run in mock mode without executing scanners"
+        required: false
+        default: "false"
 
 permissions:
   contents: read
@@ -22,7 +27,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip==23.3.1
           pip install --no-deps bandit==1.7.5 safety==2.3.5
+      - name: Mock run notice
+        if: ${{ github.event.inputs.mock == 'true' }}
+        run: echo "Mock run - scanners skipped"
       - name: Run Bandit
+        if: ${{ github.event.inputs.mock != 'true' }}
         run: bandit -r . || true
       - name: Run Safety
+        if: ${{ github.event.inputs.mock != 'true' }}
         run: safety check || true

--- a/integration_contract.md
+++ b/integration_contract.md
@@ -23,6 +23,16 @@ Messages on `security-scan` queue follow schema:
 }
 ```
 
+### GitHub Actions
+Manual dispatch enables mock runs via GitHub's API:
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <token>" \
+  https://api.github.com/repos/<owner>/<repo>/actions/workflows/security-scan.yml/dispatches \
+  -d '{"ref":"main","inputs":{"mock":"true"}}'
+```
+Setting `mock=true` runs the workflow without executing scanners while verifying configuration.
+
 ## Authentication
 - CLI/HTTP/Queue: Bearer token via `GITHUB_TOKEN` or OIDC.
 - Rate limit: 60 req/min per repo.

--- a/tests/spec_validation_test.py
+++ b/tests/spec_validation_test.py
@@ -12,3 +12,9 @@ def test_manifest_has_required_fields() -> None:
     assert data["id"] == "bwb::security-scan-workflow::v1"
     assert data["security"]["supply_chain"]["sbom"] is True
     assert data["security"]["supply_chain"]["policy"] == "fail_on_critical"
+
+
+def test_manifest_has_mock_run_input() -> None:
+    """Ensure mock_run input is declared."""
+    data = json.loads(Path("workflow_manifest.json").read_text())
+    assert any(i["name"] == "mock_run" for i in data["inputs"])

--- a/workflow_manifest.json
+++ b/workflow_manifest.json
@@ -5,7 +5,8 @@
   "business_goal": "Run EthicalCheck, Fortify, and Codacy scans to detect security issues before merge",
   "value_hypothesis": "Automated security scanning reduces vulnerabilities and improves compliance posture",
   "inputs": [
-    {"name": "repository", "type": "text", "source": "api", "validation": "<owner>/<repo>"}
+    {"name": "repository", "type": "text", "source": "api", "validation": "<owner>/<repo>"},
+    {"name": "mock_run", "type": "text", "source": "manual", "validation": "true|false"}
   ],
   "outputs": [
     {"name": "scan_report", "type": "json", "retention_days": 90, "consumer": "security-team"}


### PR DESCRIPTION
## Summary
- allow security scan workflow to run in mock mode via workflow dispatch
- add manual-mock-run workflow to dispatch mock scans
- document mock_run input in manifest, contract, and tests

## Testing
- `pre-commit run --files .github/workflows/security-scan.yml .github/workflows/manual-mock-run.yml tests/spec_validation_test.py workflow_manifest.json integration_contract.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af65c070548322994cf685c0b06291