### PR TITLE
feat: log skip reasons for Fortify and Codacy scans

### DIFF
--- a/src/codacy.py
+++ b/src/codacy.py
@@ -11,6 +11,11 @@ logger = get_logger(__name__)
 def main() -> Dict[str, str]:
     """Simulate running Codacy scan."""
     if not os.getenv("CODACY_PROJECT_TOKEN"):
+        logger.info("codacy skipped: missing CODACY_PROJECT_TOKEN")
         return {"status": "skipped"}
     logger.info("codacy started")
     return {"status": "ok"}
+
+
+if __name__ == "__main__":  # pragma: no cover - script mode
+    main()

--- a/src/fortify.py
+++ b/src/fortify.py
@@ -20,7 +20,13 @@ REQUIRED = [
 
 def main() -> Dict[str, str]:
     """Simulate running Fortify scan."""
-    if not all(os.getenv(k) for k in REQUIRED):
+    missing = [k for k in REQUIRED if not os.getenv(k)]
+    if missing:
+        logger.info("fortify skipped: missing %s", ",".join(missing))
         return {"status": "skipped"}
     logger.info("fortify started")
     return {"status": "ok"}
+
+
+if __name__ == "__main__":  # pragma: no cover - script mode
+    main()

--- a/tests/scan_skip_test.py
+++ b/tests/scan_skip_test.py
@@ -1,0 +1,17 @@
+"""Tests for scan skip behavior."""
+
+from src import codacy, fortify
+
+
+def test_codacy_skips_without_token(caplog):
+    caplog.set_level("INFO")
+    result = codacy.main()
+    assert result == {"status": "skipped"}
+    assert "codacy skipped" in caplog.text
+
+
+def test_fortify_skips_without_env(caplog):
+    caplog.set_level("INFO")
+    result = fortify.main()
+    assert result == {"status": "skipped"}
+    assert "fortify skipped" in caplog.text


### PR DESCRIPTION
## Summary
- log missing environment variables when Fortify or Codacy scans are skipped
- allow running scanners directly as scripts
- test skip behavior for missing credentials

## Testing
- `pre-commit run --files src/fortify.py src/codacy.py tests/scan_skip_test.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af668b9470832286c20659133efedf