### PR TITLE
fix: resolve markdownlint issues

### DIFF
--- a/integration_contract.md
+++ b/integration_contract.md
@@ -29,13 +29,16 @@ Messages on `security-scan` queue follow schema:
 ```
 
 ### GitHub Actions
+
 Manual dispatch enables mock runs via GitHub's API:
+
 ```bash
 curl -X POST \
   -H "Authorization: Bearer <token>" \
   https://api.github.com/repos/<owner>/<repo>/actions/workflows/security-scan.yml/dispatches \
   -d '{"ref":"main","inputs":{"mock":"true"}}'
 ```
+
 Setting `mock=true` runs the workflow without executing scanners while verifying configuration.
 
 ## Authentication


### PR DESCRIPTION
## Summary
- fix markdown lint around GitHub Actions section
- ensure fenced code blocks are surrounded by blank lines

## Testing
- `npx --yes markdownlint-cli '**/*.md' --config .markdownlint.yml --ignore-path .markdownlintignore`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af6b3d41c88322acd874a7039c65b9