### PR TITLE
Fix Codacy workflow env check

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   codacy-security-scan:
-    if: env.CODACY_PROJECT_TOKEN != ''
+    if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
     continue-on-error: true
     permissions:
       contents: read # for actions/checkout to fetch code


### PR DESCRIPTION
## Summary
- fix Codacy workflow condition to properly check project token

## Testing
- `pre-commit run --files .github/workflows/codacy.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6c3f4d888322ac9949580965f6ae