### PR TITLE
fix: guard Fortify workflow when secrets missing

### DIFF
--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -37,6 +37,15 @@ jobs:
       security-events: write
       # pull-requests: write     # Required if DO_PR_COMMENT is set to true
 
+    env:
+      FOD_TENANT: ${{ secrets.FOD_TENANT }}
+      FOD_USER: ${{ secrets.FOD_USER }}
+      FOD_PAT: ${{ secrets.FOD_PAT }}
+      SSC_URL: ${{ vars.SSC_URL }}
+      SSC_TOKEN: ${{ secrets.SSC_TOKEN }}
+      SC_CLIENT_AUTH_TOKEN: ${{ secrets.SC_CLIENT_AUTH_TOKEN }}
+      DEBRICKED_TOKEN: ${{ secrets.DEBRICKED_TOKEN }}
+
     steps:
       # Check out source code
       - name: Check Out Source Code
@@ -51,7 +60,7 @@ jobs:
       # documentation at https://github.com/fortify/github-action#readme for more information on the various
       # configuration options and available sub-actions.
       - name: Run Fortify Scan
-        if: ${{ secrets.FOD_TENANT != '' && secrets.FOD_USER != '' && secrets.FOD_PAT != '' && vars.SSC_URL != '' && secrets.SSC_TOKEN != '' && secrets.SC_CLIENT_AUTH_TOKEN != '' && secrets.DEBRICKED_TOKEN != '' }}
+        if: env.FOD_TENANT != '' && env.FOD_USER != '' && env.FOD_PAT != '' && env.SSC_URL != '' && env.SSC_TOKEN != '' && env.SC_CLIENT_AUTH_TOKEN != '' && env.DEBRICKED_TOKEN != ''
         # Specify Fortify GitHub Action version to run. As per GitHub starter workflow requirements, this example
         # uses the commit id corresponding to version 1.6.2. It is recommended to check whether any later releases
         # are available at https://github.com/fortify/github-action/releases. Depending on the amount of stability
@@ -68,9 +77,9 @@ jobs:
           ##### Remove this section if you're integrating with Fortify Hosted/Software Security Center (see below)
           ### Required configuration
           FOD_URL: https://ams.fortify.com                 # Must be hardcoded or configured through GitHub variable, not secret
-          FOD_TENANT: ${{secrets.FOD_TENANT}}              # Either tenant/user/password or client id/secret are required;
-          FOD_USER: ${{secrets.FOD_USER}}                  # these should be configured through GitHub secrets.
-          FOD_PASSWORD: ${{secrets.FOD_PAT}}
+          FOD_TENANT: ${{ env.FOD_TENANT }}               # Either tenant/user/password or client id/secret are required;
+          FOD_USER: ${{ env.FOD_USER }}                   # these should be configured through GitHub secrets.
+          FOD_PASSWORD: ${{ env.FOD_PAT }}
           # FOD_CLIENT_ID: ${{secrets.FOD_CLIENT_ID}}
           # FOD_CLIENT_SECRET: ${{secrets.FOD_CLIENT_SECRET}}
           ### Optional configuration
@@ -101,10 +110,10 @@ jobs:
           ##### Fortify Hosted / Software Security Center & ScanCentral
           ##### Remove this section if you're integrating with Fortify on Demand (see above)
           ### Required configuration
-          SSC_URL: ${{vars.SSC_URL}}                       # Must be hardcoded or configured through GitHub variable, not secret
-          SSC_TOKEN: ${{secrets.SSC_TOKEN}}                # SSC CIToken; credentials should be configured through GitHub secrets
-          SC_SAST_TOKEN: ${{secrets.SC_CLIENT_AUTH_TOKEN}} # ScanCentral SAST client_auth_token, required if SAST scan is enabled
-          DEBRICKED_TOKEN: ${{secrets.DEBRICKED_TOKEN}}    # Debricked token, required if Debricked scan is enabled
+          SSC_URL: ${{ env.SSC_URL }}                      # Must be hardcoded or configured through GitHub variable, not secret
+          SSC_TOKEN: ${{ env.SSC_TOKEN }}                  # SSC CIToken; credentials should be configured through GitHub secrets
+          SC_SAST_TOKEN: ${{ env.SC_CLIENT_AUTH_TOKEN }}   # ScanCentral SAST client_auth_token, required if SAST scan is enabled
+          DEBRICKED_TOKEN: ${{ env.DEBRICKED_TOKEN }}      # Debricked token, required if Debricked scan is enabled
           SC_SAST_SENSOR_VERSION: 24.4.0                   # Sensor version to use for the scan, required if SAST scan is enabled
           ### Optional configuration
           # SSC_LOGIN_EXTRA_OPTS: --socket-timeout=60s     # Extra 'fcli ssc session login' options


### PR DESCRIPTION
## Summary
- handle missing secrets in Fortify scan step by using env vars

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6c5dc5b48322b35a14acf56197bd