### PR TITLE
Run workflows on all branches

### DIFF
--- a/.github/workflows/Python-CI.yml
+++ b/.github/workflows/Python-CI.yml
@@ -2,12 +2,10 @@ name: Python CI
 
 on:
   push:
-    branches: [main]
     paths-ignore:
       - '**/*.md'
       - '**/*.ipynb'
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -2,7 +2,6 @@ name: Auto-merge Dependabot PRs
 
 on:
   pull_request_target:
-    branches: [main]
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 

--- a/.github/workflows/build-and-push-ghcr.yml
+++ b/.github/workflows/build-and-push-ghcr.yml
@@ -2,7 +2,6 @@ name: Build and Push Docker image to GHCR
 
 on:
   push:
-    branches: ["main"]
     tags: ["v*"]
   workflow_dispatch:
 

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -15,10 +15,8 @@ name: Codacy Security Scan
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   schedule:
     - cron: '45 23 * * 2'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,7 @@ name: CodeQL
 
 on:
   push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
   schedule:
     - cron: '0 4 * * 0'
   workflow_dispatch:

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -2,7 +2,6 @@ name: Automatic Dependency Submission (Python)
 
 on:
   push:
-    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,6 @@ name: Docker Build
 
 on:
   push:
-    branches: [ "main" ]
     paths:
       - 'docker/**'
       - '.github/workflows/docker-build.yml'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ name: Docs (MkDocs → GitHub Pages)
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
     paths:
       - "docs/**"
       - "mkdocs.yml"

--- a/.github/workflows/ethicalcheck.yml
+++ b/.github/workflows/ethicalcheck.yml
@@ -33,9 +33,7 @@ on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   # Customize trigger events based on your DevSecOps processes.
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '33 16 * * 5'
 

--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -18,10 +18,8 @@ name: Fortify AST Scan
 # Customize trigger events based on your DevSecOps process and/or policy
 on:
   push:
-    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   schedule:
     - cron: '33 2 * * 0'
   workflow_dispatch:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -2,7 +2,6 @@ name: Generate Changelog
 
 on:
   push:
-    branches: ["main"]
     paths:
       - "**/*.py"
       - "**/*.md"

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -2,7 +2,6 @@ name: Matrix CI
 
 on:
   push:
-    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -5,7 +5,6 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   push:
-    branches: ["main"]
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,12 +2,10 @@ name: pre-commit
 
 on:
   push:
-    branches: [main]
     paths-ignore:
       - '**/*.md'
       - '**/*.ipynb'
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,9 +2,7 @@ name: Release Drafter
 
 on:
   push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -2,7 +2,6 @@ name: Generate SBOM
 
 on:
   push:
-    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -2,9 +2,7 @@ name: Security Scan
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       mock:

--- a/.github/workflows/update-repo-structure.yml
+++ b/.github/workflows/update-repo-structure.yml
@@ -2,7 +2,6 @@ name: Update Repo Structure
 
 on:
   push:
-    branches: ["main"]
     paths-ignore:
       - "README.md"
       - ".github/workflows/update-repo-structure.yml"

--- a/.github/workflows/update-toc-file.yml
+++ b/.github/workflows/update-toc-file.yml
@@ -2,7 +2,6 @@ name: Update Top-Level TOC file
 
 on:
   push:
-    branches: ["main"]
     paths-ignore:
       - "Table Of Contents.md"
       - ".github/workflows/update-toc-file.yml"

--- a/.github/workflows/validate-notebooks.yml
+++ b/.github/workflows/validate-notebooks.yml
@@ -2,10 +2,8 @@ name: Validate Jupyter Notebooks
 
 on:
   push:
-    branches: [ main ]
     paths: [ "**/*.ipynb" ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Allow CI, security, and docs workflows to run on any branch
- Ensure GitHub Actions no longer skip when working outside `main`

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}')`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68af6c8158948322a95c5b11bbb40449