### PR TITLE
Fix Codacy workflow token check

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   codacy-security-scan:
-    if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
+    if: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
     continue-on-error: true
     permissions:
       contents: read # for actions/checkout to fetch code


### PR DESCRIPTION
## Summary
- fix Codacy workflow env expression to use secrets context

## Testing
- `pre-commit run --files .github/workflows/codacy.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6def04ac8322912a8b9b1471d866