### PR TITLE
chore: update workflows for current actions

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge
-        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d
+        uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,9 +14,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@v4
       - name: Create Release
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   codacy-security-scan:
-    if: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
+    if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
     continue-on-error: true
     permissions:
       contents: read # for actions/checkout to fetch code
@@ -43,7 +43,7 @@ jobs:
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@d840f886c4bd4edc059706d09c6a1586111c540b
+        uses: codacy/codacy-analysis-cli-action@v4.4.7
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,14 +15,14 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          python -m pip install pip==23.3.1
+          python -m pip install --upgrade pip
           pip install pre-commit==4.3.0
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
     steps:
       # Checkout the repository at a known commit
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@v4
 
       # Prepare a staging directory and create a ZIP of selected folders
       - name: Prepare staging
@@ -33,7 +33,7 @@ jobs:
 
       # Generate SPDX SBOM
       - name: SBOM (SPDX)
-        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c
+        uses: anchore/sbom-action@v0.20.5
         with:
           path: .
           format: spdx-json
@@ -41,7 +41,7 @@ jobs:
 
       # Generate CycloneDX SBOM
       - name: SBOM (CycloneDX)
-        uses: anchore/sbom-action@da167eac915b4e86f08b264dbdbc867b61be6f0c
+        uses: anchore/sbom-action@v0.20.5
         with:
           path: .
           format: cyclonedx-json
@@ -56,7 +56,7 @@ jobs:
 
       # Upload the ZIP and SBOM files to the GitHub release
       - name: Upload bundle to release
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- use maintained actions for Codacy, release bundle, pre-commit, auto release, and Dependabot automerge
- ensure workflows run on Node 20 compatible action versions

## Testing
- `pre-commit run --files .github/workflows/codacy.yml .github/workflows/release-bundle.yml .github/workflows/pre-commit.yml .github/workflows/auto-release.yml .github/workflows/auto-merge-dependabot.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af710e2f748322985564ea1f794688