### PR TITLE
Fix GitHub workflow skip conditions

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   release:
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   dependency-review:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   sign-release:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # The job needs write access to upload the signed artifacts, and
     # id-token to authenticate with Sigstore for keyless signing
@@ -21,7 +21,7 @@ jobs:
       id-token: write
     env:
       # Provide the tag name and repository for gh commands
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
       REPO: ${{ github.repository }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- ensure dependency review runs on PRs by removing job-level gating
- allow manual and tag-based releases to execute
- enable release signing when triggered manually
- auto-merge dependabot PRs based on author rather than event actor

## Testing
- `pre-commit run --files .github/workflows/dependency-review.yml .github/workflows/auto-release.yml .github/workflows/release-sign.yml .github/workflows/auto-merge-dependabot.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7419c39c8322a3029441aad6e26b