### PR TITLE
fix: repair security scans workflow configs

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -28,7 +28,6 @@ permissions:
 
 jobs:
   codacy-security-scan:
-    if: ${{ env.CODACY_PROJECT_TOKEN != '' }}
     continue-on-error: true
     permissions:
       contents: read # for actions/checkout to fetch code
@@ -41,11 +40,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Verify Codacy token
+        if: env.CODACY_PROJECT_TOKEN == ''
+        run: echo 'CODACY_PROJECT_TOKEN not set, skipping scan.' >> $GITHUB_STEP_SUMMARY
+
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
+        if: env.CODACY_PROJECT_TOKEN != ''
         uses: codacy/codacy-analysis-cli-action@v4.4.7
         with:
-          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
+          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token
+          # from your Codacy repository
           # You can also omit the token and run the tools that support default configurations
           project-token: ${{ env.CODACY_PROJECT_TOKEN }}
           verbose: true
@@ -59,6 +64,11 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
+        if: env.CODACY_PROJECT_TOKEN != '' && hashFiles('results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif
+
+      - name: Codacy scan summary
+        if: env.CODACY_PROJECT_TOKEN != ''
+        run: echo 'Codacy scan completed.' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ethicalcheck.yml
+++ b/.github/workflows/ethicalcheck.yml
@@ -53,6 +53,8 @@ jobs:
     if: ${{ env.ETHICALCHECK_OAS_URL != '' && env.ETHICALCHECK_EMAIL != '' }}
     continue-on-error: true
     permissions:
+      contents: read
+      security-events: write
       actions: read # required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- ensure Codacy scan runs and reports summary even when token missing
- grant ethical check workflow permissions to upload SARIF results

## Testing
- `pre-commit run --files .github/workflows/codacy.yml .github/workflows/ethicalcheck.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af73225bf4832282a204dd19c7923b