### PR TITLE
fix: update workflows and lint

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  security-events: write
 
 jobs:
   dependency-review:
@@ -16,6 +17,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,9 +15,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.10'
       - name: Install dependencies

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
     steps:
       # Checkout the repository at a known commit
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       # Prepare a staging directory and create a ZIP of selected folders
       - name: Prepare staging

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 0
 
       # Install Cosign at a pinned commit; cosign-release specifies the cosign version
       - name: Install Cosign

--- a/.github/workflows/update-repo-structure.yml
+++ b/.github/workflows/update-repo-structure.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
@@ -45,4 +45,3 @@ jobs:
           body: "Automated update of the repository structure section."
           labels: "documentation"
           add-paths: "README.md"
-          sign-commits: true

--- a/.github/workflows/update-toc-file.yml
+++ b/.github/workflows/update-toc-file.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
@@ -51,4 +51,3 @@ jobs:
           body: "Automated TOC update."
           labels: "documentation"
           add-paths: "Table Of Contents.md"
-          sign-commits: true

--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -6,12 +6,14 @@ import json
 import sys
 from importlib import metadata
 from pathlib import Path
+from typing import Mapping, cast
 
 
 def main(path: str = "sbom.json") -> None:
     packages = []
     for dist in metadata.distributions():
-        name = dist.metadata.get("Name") or dist.metadata.get("Summary") or dist.metadata.get("name", "")
+        meta = cast(Mapping[str, str], dist.metadata)
+        name = meta.get("Name") or meta.get("Summary") or meta.get("name", "")
         packages.append({"name": name, "version": dist.version})
     data = {"packages": packages}
     Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")


### PR DESCRIPTION
## Summary
- pin and update actions for dependency review, pre-commit, release bundle, repo structure, and toc workflows
- drop commit signing and add dependency review permissions
- fix generate_sbom mypy error

## Testing
- `pre-commit run --files .github/workflows/dependency-review.yml .github/workflows/pre-commit.yml .github/workflows/release-bundle.yml .github/workflows/update-repo-structure.yml .github/workflows/update-toc-file.yml scripts/generate_sbom.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af77a30f448322a527cdecc820b38b