### PR TITLE
Handle missing EthicalCheck env vars and test scan skips

### DIFF
--- a/src/ethicalcheck.py
+++ b/src/ethicalcheck.py
@@ -10,7 +10,13 @@ logger = get_logger(__name__)
 
 def main() -> Dict[str, str]:
     """Simulate running EthicalCheck scan."""
-    if not os.getenv("ETHICALCHECK_OAS_URL") or not os.getenv("ETHICALCHECK_EMAIL"):
+    required = ("ETHICALCHECK_OAS_URL", "ETHICALCHECK_EMAIL")
+    if not all(os.getenv(var) for var in required):
+        logger.info("ethicalcheck skipped: missing %s", " or ".join(required))
         return {"status": "skipped"}
     logger.info("ethicalcheck started")
     return {"status": "ok"}
+
+
+if __name__ == "__main__":  # pragma: no cover - script mode
+    main()

--- a/tests/scan_skip_test.py
+++ b/tests/scan_skip_test.py
@@ -1,6 +1,9 @@
 """Tests for scan skip behavior."""
 
+# isort: skip_file
+
 from src import codacy, fortify
+from src import ethicalcheck
 
 
 def test_codacy_skips_without_token(caplog):
@@ -8,6 +11,16 @@ def test_codacy_skips_without_token(caplog):
     result = codacy.main()
     assert result == {"status": "skipped"}
     assert "codacy skipped" in caplog.text
+
+
+def test_ethicalcheck_skips_without_env(monkeypatch, caplog):
+    """EthicalCheck should skip if required environment variables are missing."""
+    caplog.set_level("INFO")
+    monkeypatch.delenv("ETHICALCHECK_OAS_URL", raising=False)
+    monkeypatch.delenv("ETHICALCHECK_EMAIL", raising=False)
+    result = ethicalcheck.main()
+    assert result == {"status": "skipped"}
+    assert "ethicalcheck skipped" in caplog.text
 
 
 def test_fortify_skips_without_env(caplog):


### PR DESCRIPTION
## Summary
- consolidate EthicalCheck environment variable checks and log skip reason
- add test covering EthicalCheck skip behaviour
- separate EthicalCheck import in skip test to avoid merge conflicts

## Testing
- `pre-commit run --files src/ethicalcheck.py tests/scan_skip_test.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7ac0be0c832294cd54183443ce6d