### PR TITLE
Skip EthicalCheck workflow when variables missing

### DIFF
--- a/.github/workflows/ethicalcheck.yml
+++ b/.github/workflows/ethicalcheck.yml
@@ -45,8 +45,8 @@ permissions:
   security-events: write
 
 env:
-  ETHICALCHECK_OAS_URL: ${{ vars.ETHICALCHECK_OAS_URL || 'https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml' }}
-  ETHICALCHECK_EMAIL: ${{ vars.ETHICALCHECK_EMAIL || 'devnull@example.com' }}
+  ETHICALCHECK_OAS_URL: ${{ vars.ETHICALCHECK_OAS_URL || '' }}
+  ETHICALCHECK_EMAIL: ${{ vars.ETHICALCHECK_EMAIL || '' }}
 
 jobs:
   Trigger_EthicalCheck:


### PR DESCRIPTION
## Summary
- skip running EthicalCheck workflow when required variables are not set

## Testing
- `pre-commit run --files .github/workflows/ethicalcheck.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af848599848322aa96093e1ea06d1d