### PR TITLE
Fix Docker CLI bundle path and clarify Fortify secrets

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,13 +5,13 @@ on:
     paths:
       - 'docker/**'
       - '.github/workflows/docker-build.yml'
-      - 'CLI Bundle/**'
+      - 'cli_bundle/**'
       - 'requirements.txt'
   pull_request:
     paths:
       - 'docker/**'
       - '.github/workflows/docker-build.yml'
-      - 'CLI Bundle/**'
+      - 'cli_bundle/**'
       - 'requirements.txt'
   workflow_dispatch:
 

--- a/.github/workflows/docker-debug.yml
+++ b/.github/workflows/docker-debug.yml
@@ -20,7 +20,7 @@ jobs:
           echo "---- head of docker/Dockerfile ----"
           sed -n '1,120p' docker/Dockerfile || true
           echo "---- check requirements file ----"
-          ls -la "CLI Bundle" || true
+          ls -la "cli_bundle" || true
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
       - name: Build (no push)
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83

--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Check Out Source Code
         uses: actions/checkout@v4
 
+      - name: Fortify secrets check
+        if: ${{ env.FOD_TENANT == '' || env.FOD_USER == '' || env.FOD_PAT == '' || env.SSC_URL == '' || env.SSC_TOKEN == '' || env.SC_CLIENT_AUTH_TOKEN == '' || env.DEBRICKED_TOKEN == '' }}
+        run: |
+          echo 'Skipping Fortify scan: required secrets are not configured.'
+
       # Perform SAST and/or SCA scan via Fortify on Demand/Fortify Hosted/ScanCentral SAST/Debricked. Based on
       # configuration, the Fortify GitHub Action can optionally set up the application version/release, generate
       # job summaries and Pull Request comments, and/or export SAST results to the GitHub code scanning dashboard.


### PR DESCRIPTION
## Summary
- standardize `cli_bundle` path in Docker build workflows
- emit clear message when Fortify secrets are missing

## Testing
- `pre-commit run --files .github/workflows/docker-build.yml .github/workflows/docker-debug.yml .github/workflows/fortify.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af8a2ccd088322ace5892b4c586fe4