### PR TITLE
fix: correct env reference in EthicalCheck workflow

### DIFF
--- a/.github/workflows/ethicalcheck.yml
+++ b/.github/workflows/ethicalcheck.yml
@@ -50,7 +50,7 @@ env:
 
 jobs:
   Trigger_EthicalCheck:
-    if: ${{ env.ETHICALCHECK_OAS_URL != '' && env.ETHICALCHECK_EMAIL != '' }}
+    if: ${{ vars.ETHICALCHECK_OAS_URL != '' && vars.ETHICALCHECK_EMAIL != '' }}
     continue-on-error: true
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- fix EthicalCheck workflow by using vars context in job condition

## Testing
- `pre-commit run --files .github/workflows/ethicalcheck.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af8bbb0748832293f3a5afb5973a07