### PR TITLE
fix: update workflow actions

### DIFF
--- a/.github/workflows/Python-CI.yml
+++ b/.github/workflows/Python-CI.yml
@@ -15,9 +15,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Python 3.10
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Python syntax & encoding check (targets known problem files)

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
       - name: Build image (no push)

--- a/.github/workflows/docker-debug.yml
+++ b/.github/workflows/docker-debug.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       BUILDKIT_PROGRESS: plain
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Show context
         run: |
           pwd && ls -la

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - run: |

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -18,10 +18,10 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -19,7 +19,7 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v4
         with:
           name: sbom-spdx
           path: sbom.spdx.json

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -17,8 +17,8 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install scanning tools

--- a/.github/workflows/update-repo-structure.yml
+++ b/.github/workflows/update-repo-structure.yml
@@ -23,10 +23,10 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/update-toc-file.yml
+++ b/.github/workflows/update-toc-file.yml
@@ -23,10 +23,10 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/validate-notebooks.yml
+++ b/.github/workflows/validate-notebooks.yml
@@ -14,17 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
       - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: nbqa-${{ runner.os }}-${{ hashFiles('**/*.ipynb') }}


### PR DESCRIPTION
## Summary
- fix actions/checkout uses by pinning to v4 for stability
- use actions/setup-python v5 across workflows
- refresh SBOM artifact upload to latest actions/upload-artifact

## Testing
- `pre-commit run --files .github/workflows/Python-CI.yml .github/workflows/codeql.yml .github/workflows/docker-build.yml .github/workflows/docker-debug.yml .github/workflows/docs.yml .github/workflows/generate-changelog.yml .github/workflows/sbom.yml .github/workflows/security-scan.yml .github/workflows/update-repo-structure.yml .github/workflows/update-toc-file.yml .github/workflows/validate-notebooks.yml`


------
https://chatgpt.com/codex/tasks/task_e_68af99a1d5c08322b402cc22309527fb