### PR TITLE
fix: scope SBOM to release bundle

### DIFF
--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -16,34 +16,34 @@ jobs:
     # This job needs write access to upload the bundle and SBOMs
     permissions:
       contents: write
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
     steps:
       # Checkout the repository at a known commit
       - uses: actions/checkout@v4
 
       # Prepare a staging directory and create a ZIP of selected folders
       - name: Prepare staging
-        env:
-          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           rm -rf dist
           mkdir -p dist
-          zip -r "dist/GCP_${TAG}_Field_Kit.zip" "cli_bundle" "Documents" "scripts" \
+          zip -r "dist/GCP_${RELEASE_TAG}_Field_Kit.zip" "cli_bundle" "Documents" "scripts" \
             -x "*.git*" "*.github*"
 
-      # Generate SPDX SBOM
+      # Generate SPDX SBOM for the bundled artifact
       - name: SBOM (SPDX)
         uses: anchore/sbom-action@v0.20.5
         with:
-          path: .
+          path: dist/GCP_${{ env.RELEASE_TAG }}_Field_Kit.zip
           format: spdx-json
           output-file: dist/sbom.spdx.json
 
-      # Generate CycloneDX SBOM
+      # Generate CycloneDX SBOM for the bundled artifact
       - name: SBOM (CycloneDX)
         uses: anchore/sbom-action@v0.20.5
         with:
-          path: .
+          path: dist/GCP_${{ env.RELEASE_TAG }}_Field_Kit.zip
           format: cyclonedx-json
           output-file: dist/sbom.cdx.json
 


### PR DESCRIPTION
## Summary
- scope SBOM generation to release archive in `release-bundle` workflow
- expose release tag to job steps

## Testing
- `pre-commit run --files .github/workflows/release-bundle.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0b8f47bb4832286239430eaea5bf4