### PR TITLE
fix: streamline markdownlint workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -23,8 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - name: Run MarkdownLint
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20.0.0
         with:
-          node-version: 20
-      - run: npm install -g markdownlint-cli@0.45.0
-      - run: markdownlint '**/*.md' --config .markdownlint.yml --ignore-path .markdownlintignore
+          globs: "**/*.md"
+          config: .markdownlint.yml
+          ignore: .markdownlintignore

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,10 +1,10 @@
 Notebooks/
 Documents/
 GCP-All-Variants/
-GCP\ Runners/
+GCP Runners/
 cli_bundle/
-Table\ Of\ Contents.md
-GCP\ Current\ Version(V50\ Flagship\ Edition).md
+Table Of Contents.md
+GCP Current Version(V50 Flagship Edition).md
 LICENSE.md
 README.md
 CHANGELOG.md


### PR DESCRIPTION
## Summary
- replace manual npm install with markdownlint-cli2 action
- remove escaped spaces in markdownlint ignore patterns

## Testing
- `pre-commit run --files .markdownlintignore .github/workflows/markdownlint.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b0b90e68c483229772b3182043b5de