### PR TITLE
ci: drop Python 3.12 from matrix

### DIFF
--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- remove Python 3.12 from CI test matrix while dependencies stabilize

## Testing
- `pre-commit run --files .github/workflows/matrix-ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0c8bd3f5c8322bfaa2554cfb7a2ed