### PR TITLE
fix: correct changelog header

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -77,7 +77,7 @@ def main() -> None:
         if not assigned:
             GROUPS["Miscellaneous Tasks"].append(msg)
 
-    lines = ["# GRCP Changelog", ""]
+    lines = ["# GCP Changelog", ""]
     for group, commits in GROUPS.items():
         if commits:
             lines.append(f"### {group}")


### PR DESCRIPTION
## Summary
- fix typo in changelog header to reflect project name

## Testing
- `pre-commit run --files scripts/generate_changelog.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0c8ea61f08322994243c9165e2f48