### PR TITLE
fix: run OpenSSF Scorecard only on main branch

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- restrict OpenSSF Scorecard workflow push trigger to the default branch

## Testing
- `pre-commit run --files .github/workflows/ossf-scorecard.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0cfbd63008322aab9e59571baea65