### PR TITLE
chore: fix SBOM generator metadata typing

### DIFF
--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -6,12 +6,14 @@ import json
 import sys
 from importlib import metadata
 from pathlib import Path
+from typing import Mapping, cast
 
 
 def main(path: str = "sbom.json") -> None:
     packages = []
     for dist in metadata.distributions():
-        name = dist.metadata.get("Name") or dist.metadata.get("Summary") or dist.metadata.get("name", "")
+        meta = cast(Mapping[str, str], dist.metadata)
+        name = meta.get("Name") or meta.get("Summary") or meta.get("name", "")
         packages.append({"name": name, "version": dist.version})
     data = {"packages": packages}
     Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")


### PR DESCRIPTION
## Summary
- cast distribution metadata to mapping in SBOM generator

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0cfe6024883228dba207b8bcb3483