### PR TITLE
Fix pre-commit formatting and metadata handling

### DIFF
--- a/scripts/generate_sbom.py
+++ b/scripts/generate_sbom.py
@@ -11,7 +11,12 @@ from pathlib import Path
 def main(path: str = "sbom.json") -> None:
     packages = []
     for dist in metadata.distributions():
-        name = dist.metadata.get("Name") or dist.metadata.get("Summary") or dist.metadata.get("name", "")
+        meta = dist.metadata
+        name = (
+            meta.get_all("Name", [""])[0]
+            or meta.get_all("Summary", [""])[0]
+            or meta.get_all("name", [""])[0]
+        )
         packages.append({"name": name, "version": dist.version})
     data = {"packages": packages}
     Path(path).write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/scripts/update_repo_structure.py
+++ b/scripts/update_repo_structure.py
@@ -29,8 +29,8 @@ EXCLUDE_FILES = {".DS_Store"}
 MAX_DEPTH = 2  # increase to 3+ if you want deeper trees
 MAX_ENTRIES = 500  # safety cap per directory
 
-BEGIN = "<!-- BEGIN REPO TREE -->"
-END = "<!-- END REPO TREE -->"
+BEGIN = "<!-- BEGIN:REPO_STRUCTURE -->"
+END = "<!-- END:REPO_STRUCTURE -->"
 
 
 def build_tree(root: Path, prefix: str = "", depth: int = 0) -> str:


### PR DESCRIPTION
## Summary
- update repo structure script to use explicit HTML markers
- revise SBOM generation to use `PackageMetadata.get_all` for mypy compatibility

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0d619e6cc832282dda0b7491b82fd