### PR TITLE
fix: use release tag for bundle artifacts

### DIFF
--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -16,14 +16,14 @@ jobs:
     # This job needs write access to upload the bundle and SBOMs
     permissions:
       contents: write
+    env:
+      TAG: ${{ github.event.release.tag_name || github.ref_name }}
     steps:
       # Checkout the repository at a known commit
       - uses: actions/checkout@v4
 
       # Prepare a staging directory and create a ZIP of selected folders
       - name: Prepare staging
-        env:
-          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           rm -rf dist
@@ -61,7 +61,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            dist/GCP_${{ github.ref_name }}_Field_Kit.zip
+            dist/GCP_${TAG}_Field_Kit.zip
             dist/sbom.spdx.json
             dist/sbom.cdx.json
             dist/SHA256SUMS.txt


### PR DESCRIPTION
## Summary
- ensure release bundle workflow uses release tag for artifact names

## Testing
- `pre-commit run --files .github/workflows/release-bundle.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b20f72137c8322b3a481c40344ce01