### PR TITLE
fix docs workflow permissions for MkDocs pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065


### PR DESCRIPTION
## Summary
- grant `pages: write` permission to `Docs (MkDocs → GitHub Pages)` build job so configure-pages can run

## Testing
- `pre-commit run --files .github/workflows/docs.yml`
- `mkdocs build --strict --site-dir site`


------
https://chatgpt.com/codex/tasks/task_e_68b20ff55aa0832291796d2c67739b3f