### PR TITLE
fix: refine MkDocs workflow triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,11 @@ name: Docs (MkDocs → GitHub Pages)
 on:
   workflow_dispatch:
   push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  pull_request:
     paths:
       - "docs/**"
       - "mkdocs.yml"
@@ -36,6 +41,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- ensure docs workflow only deploys from `main`
- build docs on pull requests while avoiding deployment

## Testing
- `pre-commit run --files .github/workflows/docs.yml`
- `mkdocs build --strict --site-dir site`


------
https://chatgpt.com/codex/tasks/task_e_68b20ff55aa0832291796d2c67739b3f