### PR TITLE
fix: use Python 3.11 for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - run: |
           python -m pip install --upgrade pip==23.3.1
           pip install --require-hashes -r .github/workflows/docs-requirements.txt


### PR DESCRIPTION
## Summary
- run docs build with Python 3.11 to match dependency hashes

## Testing
- `pre-commit run --files .github/workflows/docs.yml`
- `mkdocs build --strict --site-dir site`


------
https://chatgpt.com/codex/tasks/task_e_68b20ff55aa0832291796d2c67739b3f