### PR TITLE
chore: limit toc workflow to main branch

### DIFF
--- a/.github/workflows/update-toc-file.yml
+++ b/.github/workflows/update-toc-file.yml
@@ -2,6 +2,8 @@ name: Update Top-Level TOC file
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - "Table Of Contents.md"
       - ".github/workflows/update-toc-file.yml"


### PR DESCRIPTION
## Summary
- run the auto-generated Table Of Contents workflow only on the main branch

## Testing
- `pre-commit run --files .github/workflows/update-toc-file.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b21016f8508322983f28ace318289d