### PR TITLE
ci: allow TOC workflow to create pull requests

### DIFF
--- a/.github/workflows/update-toc-file.yml
+++ b/.github/workflows/update-toc-file.yml
@@ -10,7 +10,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: toc-file
@@ -18,9 +19,6 @@ concurrency:
 
 jobs:
   build-toc:
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8


### PR DESCRIPTION
## Summary
- grant write permissions so TOC workflow can open PRs
- simplify by removing redundant job-level permissions

## Testing
- `pre-commit run --files .github/workflows/update-toc-file.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b21016f8508322983f28ace318289d