### PR TITLE
chore(ci): allow labeling repo structure PR

### DIFF
--- a/.github/workflows/update-repo-structure.yml
+++ b/.github/workflows/update-repo-structure.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8


### PR DESCRIPTION
## Summary
- allow repo structure workflow to apply labels by granting `issues: write`

## Testing
- `pre-commit run --files .github/workflows/update-repo-structure.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b21027e5b48322af1dbd21644c01b9