### PR TITLE
chore(workflow): streamline changelog generation

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -6,6 +6,9 @@ on:
       - "**/*.py"
       - "**/*.md"
       - "**/*.yml"
+    paths-ignore:
+      - "CHANGELOG.md"
+      - ".github/workflows/generate-changelog.yml"
   workflow_dispatch:
 
 permissions:
@@ -24,12 +27,6 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
-
-      # Install dependencies required by the changelog script
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip==23.3.1
-          pip install --no-deps gitpython==3.1.45
 
       # Count commits since the last changelog update
       - name: Count commits


### PR DESCRIPTION
## Summary
- avoid self-triggering when changelog updates
- drop obsolete GitPython install

## Testing
- `pre-commit run --files .github/workflows/generate-changelog.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21040aff08322bbb7781921fb73d4