### PR TITLE
chore(changelog): refine changelog workflow

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -2,10 +2,14 @@ name: Generate Changelog
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "**/*.py"
       - "**/*.md"
       - "**/*.yml"
+    paths-ignore:
+      - "CHANGELOG.md"
   workflow_dispatch:
 
 permissions:
@@ -24,12 +28,6 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
-
-      # Install dependencies required by the changelog script
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip==23.3.1
-          pip install --no-deps gitpython==3.1.45
 
       # Count commits since the last changelog update
       - name: Count commits

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -47,6 +47,8 @@ PATTERNS = [
     (r".*security", "Security"),
 ]
 
+CHANGELOG_SKIP_RE = re.compile(r"^chore\(changelog\)", re.IGNORECASE)
+
 
 def _git_log() -> List[str]:
     """Return commit messages using the ``git`` command line."""
@@ -68,6 +70,8 @@ def main() -> None:
     messages = _git_log()
 
     for msg in messages:
+        if CHANGELOG_SKIP_RE.search(msg):
+            continue
         assigned = False
         for pattern, group in PATTERNS:
             if re.search(pattern, msg, re.IGNORECASE):
@@ -77,7 +81,7 @@ def main() -> None:
         if not assigned:
             GROUPS["Miscellaneous Tasks"].append(msg)
 
-    lines = ["# GRCP Changelog", ""]
+    lines = ["# GCP Changelog", ""]
     for group, commits in GROUPS.items():
         if commits:
             lines.append(f"### {group}")


### PR DESCRIPTION
## Summary
- limit changelog workflow to `main` and ignore self-updates
- drop unused GitPython install step
- skip changelog commits in generator and fix heading

## Testing
- `pre-commit run --files .github/workflows/generate-changelog.yml scripts/generate_changelog.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b21040aff08322bbb7781921fb73d4