### PR TITLE
chore: set run names for key workflows

### DIFF
--- a/.github/workflows/Python-CI.yml
+++ b/.github/workflows/Python-CI.yml
@@ -1,4 +1,5 @@
 name: Python CI
+run-name: ${{ github.workflow }}
 
 on:
   push:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,4 +1,5 @@
 name: Auto Release
+run-name: ${{ github.workflow }}
 
 on:
   push:

--- a/.github/workflows/build-and-push-ghcr.yml
+++ b/.github/workflows/build-and-push-ghcr.yml
@@ -1,4 +1,5 @@
 name: Build and Push Docker image to GHCR
+run-name: ${{ github.workflow }}
 
 on:
   push:

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -12,6 +12,7 @@
 # https://github.com/codacy/codacy-analysis-cli.
 
 name: Codacy Security Scan
+run-name: ${{ github.workflow }}
 
 on:
   push:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,5 @@
 name: CodeQL
+run-name: ${{ github.workflow }}
 
 on:
   push:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,4 +1,5 @@
 name: Markdown Lint
+run-name: ${{ github.workflow }}
 
 on:
   push:

--- a/.github/workflows/trigger-all-workflows.yml
+++ b/.github/workflows/trigger-all-workflows.yml
@@ -1,4 +1,5 @@
 name: Trigger All Workflows
+run-name: ${{ github.workflow }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- ensure workflow runs show their workflow name rather than commit message
- set explicit `run-name` for major actions workflows

## Testing
- `pre-commit run --files .github/workflows/Python-CI.yml .github/workflows/codeql.yml .github/workflows/codacy.yml .github/workflows/auto-release.yml .github/workflows/build-and-push-ghcr.yml .github/workflows/trigger-all-workflows.yml .github/workflows/markdownlint.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b222696cd48322b1fbb08ce5495b0f